### PR TITLE
Firefox は background の指定が異なる

### DIFF
--- a/firefox.json
+++ b/firefox.json
@@ -3,5 +3,8 @@
     "gecko": {
       "id": "streaming-plus-sequencer@windyakin.net"
     }
+  },
+  "background": {
+    "scripts": ["service_worker/index.js"]
   }
 }


### PR DESCRIPTION
Firefox の background 指定は `service_worker` が使えない


<img width="808" alt="スクリーンショット 2023-02-18 11 32 06" src="https://user-images.githubusercontent.com/3339003/219827149-cc0f6feb-bc8c-4140-815d-9d6486f39a37.png">

src: https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background